### PR TITLE
Included string.h to allow use of strdup

### DIFF
--- a/Sources/SwiftH3/H3Index.swift
+++ b/Sources/SwiftH3/H3Index.swift
@@ -1,4 +1,4 @@
-import Foundation
+#include <string.h>
 import Ch3
 
 /// Represents an index in H3

--- a/Sources/SwiftH3/H3Index.swift
+++ b/Sources/SwiftH3/H3Index.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Ch3
 
 /// Represents an index in H3


### PR DESCRIPTION
The current version of XCode complains when H3Index calls `strdup()`, which isn't in the standard C library. Adding `#include <string.h>` to the bridge file fixes this issue.