### PR TITLE
Fix description memory management

### DIFF
--- a/Sources/SwiftH3/H3Index.swift
+++ b/Sources/SwiftH3/H3Index.swift
@@ -150,9 +150,10 @@ extension H3Index: CustomStringConvertible {
 
     /// String description of the index
     public var description: String {
-        let cString = strdup("")
+        let cString = UnsafeMutablePointer<CChar>.allocate(capacity: 17)
+        defer { cString.deallocate() }
         h3ToString(value, cString, 17)
-        return String(cString: cString!)
+        return String(cString: cString)
     }
 
 }


### PR DESCRIPTION
## Summary
- fix memory handling in the `description` property

## Testing
- `swift test` *(fails: unable to access https://github.com/bdotdub/Ch3.git)*

------
https://chatgpt.com/codex/tasks/task_e_684ed0041b288330a5fdbfcca80272eb